### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # PowerShellGallery
-Module for interacting with the PowerShell Gallery
+
+PowerShellGallery is a PowerShell module for interacting with the PowerShell Gallery.
+
+## Installation
+
+Install the module from the PowerShell Gallery:
+
+```powershell
+Install-PSResource -Name PowerShellGallery
+Import-Module -Name PowerShellGallery
+```
+
+## Documentation
+
+Documentation is published at [psmodule.io/PowerShellGallery](https://psmodule.io/PowerShellGallery/).
+
+Use PowerShell help and command discovery for module details:
+
+```powershell
+Get-Command -Module PowerShellGallery
+Get-Help <CommandName> -Examples
+```
+
+## Contributing
+
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.


### PR DESCRIPTION
README pages now act as concise landing pages. Implemented modules point users to installation, psmodule.io, and PowerShell help instead of duplicating command reference content. Placeholder and in-progress modules now state their status clearly so users are not shown scaffold examples as working usage.

> ⚠️ This PR has no linked issue. Consider creating one for traceability.

## Changed: README pages defer to generated documentation

Implemented module READMEs now provide a short overview, installation commands, and links to generated documentation. Command usage remains in PowerShell help and generated docs.

```powershell
Get-Command -Module <ModuleName>
Get-Help -Name 'CommandName' -Examples
```

## Changed: Placeholder modules identify their status

Repositories that still contain scaffold or stub module code now say they are placeholders or in progress instead of showing template commands as if they worked.

## Technical Details

- Updates `README.md` only.
- Aligns repository READMEs with the default introduced in `PSModule/Template-PSModule`.
- Keeps command-level details out of README pages to avoid duplicating generated module documentation.
